### PR TITLE
No second-level menu items in main menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,7 @@ local.properties
 .cproject
 
 # PDT-specific
-.buildpat
-.lol
+.buildpath
 
 
 #################


### PR DESCRIPTION
The change I'm pushing here limits the main menu to just the top-level items. Unfortunately, main menus with multiple levels of items have a poor appearance with this theme, and while using hover dropdowns for menu items with children could work, I feel that doing things that way doesn't quite fit into the Metro/Modern aesthetic.
